### PR TITLE
Upgrade youtube transcript api to v1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ starlette==0.38.4
 typing_extensions==4.12.2
 tzdata==2024.1
 uvicorn==0.30.6
-youtube-transcript-api==0.6.2
+youtube-transcript-api==1.1.0
 yt-dlp==2024.12.23  # Add yt-dlp to the requirements
 #----------------------------------------
 boto3==1.26.79


### PR DESCRIPTION
The YouTube Transcript API was down due to some downstream changes by Google, more info [here](https://github.com/jdepoix/youtube-transcript-api/issues/414#issuecomment-2947457905).

This updated version should get around that by using a separate transcripts endpoint which still isn't enforced by PO tokens. 
More info [here](https://github.com/jdepoix/youtube-transcript-api/issues/429#issuecomment-2964476175)