### PR TITLE
Add foreign language api handling

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -71,14 +71,19 @@ def get_video_details(video_id: str):
 transcription_statuses = {}
 def fetch_video_transcript(video_id: str):
     try:
-        # Attempt to fetch the YouTube transcript
+        # Attempt to fetch the YouTube transcript list object
         if env == "local" or env =="docker":
                 transcript_list = YouTubeTranscriptApi.list_transcripts(video_id) #Get object with list of available transcripts
         else:
                 transcript_list = YouTubeTranscriptApi.list_transcripts(video_id, proxies = PROXIES)
-
-        # Get first transcript in transcript list 
-        transcript_object = next(iter(transcript_list)) # Turn transcript object into iterable and get first item
+        # Look for an English transcript first
+        try:
+            transcript_object = transcript_list.find_transcript(['en'])
+        # Otherwise fallback to next available transcript
+        except Exception as e:
+            print("English transcript not found.")
+            # Get first transcript object in transcript list 
+            transcript_object = next(iter(transcript_list)) # Turn transcript object into iterable and get first item
         
         raw_transcript = transcript_object.fetch().to_raw_data() #Get the object's transcript and convert it to list of dictionaries
         formatted_transcript = format_transcript(raw_transcript)

--- a/app/service.py
+++ b/app/service.py
@@ -73,10 +73,15 @@ def fetch_video_transcript(video_id: str):
     try:
         # Attempt to fetch the YouTube transcript
         if env == "local" or env =="docker":
-            transcript = YouTubeTranscriptApi.get_transcript(video_id)
+                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
         else:
-            transcript = YouTubeTranscriptApi.get_transcript(video_id, proxies=PROXIES)
+                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id, proxies = PROXIES)
+
+        transcript_object = next(iter(transcript_list))
+        transcript = transcript_object.fetch().to_raw_data()
+
         formatted_transcript = format_transcript(transcript)
+        print(f"✅Succesfully retrieved transcript from YoutubeTranscriptApi in {transcript_object.language}")
         return formatted_transcript
 
     except (NoTranscriptFound, TranscriptsDisabled):

--- a/app/service.py
+++ b/app/service.py
@@ -73,15 +73,16 @@ def fetch_video_transcript(video_id: str):
     try:
         # Attempt to fetch the YouTube transcript
         if env == "local" or env =="docker":
-                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id) #Get object with list of available transcripts
         else:
                 transcript_list = YouTubeTranscriptApi.list_transcripts(video_id, proxies = PROXIES)
 
-        transcript_object = next(iter(transcript_list))
-        transcript = transcript_object.fetch().to_raw_data()
-
-        formatted_transcript = format_transcript(transcript)
-        print(f"✅Succesfully retrieved transcript from YoutubeTranscriptApi in {transcript_object.language}")
+        # Get first transcript in transcript list 
+        transcript_object = next(iter(transcript_list)) # Turn transcript object into iterable and get first item
+        
+        raw_transcript = transcript_object.fetch().to_raw_data() #Get the object's transcript and convert it to list of dictionaries
+        formatted_transcript = format_transcript(raw_transcript)
+        print(f"✅ Succesfully retrieved transcript from YoutubeTranscriptApi in {transcript_object.language}")
         return formatted_transcript
 
     except (NoTranscriptFound, TranscriptsDisabled):


### PR DESCRIPTION
# Problem

- Errors when getting transcript in **non-English languages**
- This stemmed from the Youtube Transcript API, and how we were interacting with it

# Why was this happening?
- `YouTubeTranscriptApi.get_transcript(video_id)` only looks for english transcriptions by default
- We want to grab whatever transcript is available regardless of language 
- Youtube API does not have this feature directly

# Solution

- The library has the method `YouTubeTranscriptApi.list_transcripts(video_id) `. This method returns an object with information on all available transcripts. Again, no feature to just grab any transcript that is available
- The object is iterable however, so we can turn it into an iterator in order to get the first entry. This will prioritize manually generated transcripts, and the transcript with highest alphabetical order
- You can now obtain transcripts in any language 

# Video

- The first clip features an auto-generated Portuguese transcript. Processing succeeds.
- The second clip is in Japanese, and processes successfully. But when we check the logs, it says it fetched the Arabic transcript.. why? This video has several manually generated transcripts in multiple languages. However the first item in the iterator, again, prioritizes manual transcripts, and alphabetical order (Arabic starts with A)
- This is ok because GPT can process the transcript and will most often get back to us in English, **regardless of the transcript language**
**- BUT IF WE DECIDE WE WANT TO ACCOUNT FOR THE LANGUAGE OF THE VIDEO, ADJUSTMENTS MAY BE NECESSARY IN THE FUTURE**

https://github.com/user-attachments/assets/99b5a83f-1b86-46bf-8b34-e10aae46ebb3

