### PR TITLE
Fix YouTubeTranscriptApi usage and proxy configuration

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -21,10 +21,10 @@ env = os.getenv("ENVIRONMENT")
 # Define proxy settings
 SMARTPROXY_USER = os.getenv("SMARTPROXY_USER")
 SMARTPROXY_PASS = os.getenv("SMARTPROXY_PASS")
-PROXIES = {
-    "http": f"http://{SMARTPROXY_USER}:{SMARTPROXY_PASS}@gate.smartproxy.com:10001",
-    "https": f"http://{SMARTPROXY_USER}:{SMARTPROXY_PASS}@gate.smartproxy.com:10001",
-}
+proxy_config = GenericProxyConfig(
+    http_url=f"http://{SMARTPROXY_USER}:{SMARTPROXY_PASS}@gate.smartproxy.com:10001",
+    https_url=f"http://{SMARTPROXY_USER}:{SMARTPROXY_PASS}@gate.smartproxy.com:10001"
+)
 
 def retry_with_backoff(func, max_retries=3, base_delay=1, max_delay=10, backoff_factor=2):
     """
@@ -103,9 +103,11 @@ def fetch_video_transcript(video_id: str):
     def attempt_youtube_transcript():
         # Attempt to fetch the YouTube transcript list object
         if env == "local" or env =="docker":
-            transcript_list = YouTubeTranscriptApi.list(video_id) #Get object with list of available transcripts
+            ytt_api = YouTubeTranscriptApi()
+            transcript_list = ytt_api.list(video_id) #Get object with list of available transcripts
         else:
-            transcript_list = YouTubeTranscriptApi.list(video_id, proxies = PROXIES)
+            ytt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
+            transcript_list = ytt_api.list(video_id)
         # Look for an English transcript first
         try:
             transcript_object = transcript_list.find_transcript(['en'])


### PR DESCRIPTION
The changes made here https://github.com/Learning-Mode-AI/Learning-Mode-AI-info-service/pull/11 did not work once it was deployed. Was seeing the following error:
```
2025-10-24T22:01:42.617-04:00 Attempt 1 failed: list() missing 1 required positional argument: 'video_id'. Retrying in 1.05 seconds...
``` 
Once I fixed that by using `ytt_api.list(video_id)` I was seeing the error:
```
[youtube] Extracting URL: https://www.youtube.com/watch?v=AknbizcLq4w Attempt 1 failed: HTTPSConnectionPool(host='www.youtube.com', port=443): Max retries exceeded with url: /watch?v=AknbizcLq4w (Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 407 Proxy Authentication Required'))). Retrying in 1.01 seconds... Attempt 2 failed: HTTPSConnectionPool(host='www.youtube.com', port=443): Max retries exceeded with url: /watch?v=AknbizcLq4w (Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 407 Proxy Authentication Required'))). Retrying in 2.13 seconds...
```
Fixed using proper format for proxy usage highlighted in the [docs of the api here ](https://github.com/jdepoix/youtube-transcript-api?tab=readme-ov-file#working-around-ip-bans-requestblocked-or-ipblocked-exception)

Changes:

- Fixed YouTubeTranscriptApi usage from static method to instance method
- Updated proxy configuration to use GenericProxyConfig instead of dictionary format

Technical Details:

- Changed YouTubeTranscriptApi.list(video_id) to ytt_api.list(video_id)
- Replaced PROXIES dict with proxy_config = GenericProxyConfig(...)

Impact:

- Resolves "missing 1 required positional argument" error
- Ensures proper proxy configuration for different environments